### PR TITLE
docs: add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,34 @@
+name: Bug Report
+description: Report a bug with the game.
+body:
+  - type: markdown
+    attributes:
+      value: "# Bug report"
+  - type: textarea
+    id: bugdescription
+    attributes:
+      label: What bug did you encounter?
+      description: Please provide a clear description of the issue.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Describe what you did to encounter this bug.
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Attach any relevant screenshots here.
+    validations:
+      required: false
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional Information
+      description: Is there anything else we should know?
+    validations:
+      required: false


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This adds a template for people to fill out when submitting bug reports.

The template appears as a fillable form:

![image](https://user-images.githubusercontent.com/63889819/147155269-41c9f35d-012f-421e-a660-57c0e68b9e5d.png)
