### PR TITLE
Bug Fix: Resolve an issue with month day 0

### DIFF
--- a/game/scripts/calendar.rpy
+++ b/game/scripts/calendar.rpy
@@ -27,6 +27,8 @@ init python:
             if self.day > self.days_count[self.month]:
                 self.day = self.day - self.days_count[self.month] - 1
                 self.month += 1 # new month
+                if self.day <= 0:
+                    self.day = 1
                 if self.month > 12: 
                     self.month = 1 # back to January
                     self.year += 1 # increment year


### PR DESCRIPTION
This fix should prevent any issues with the day of the month being zero or a negative number. This is handy for days such as October 25th.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
My original issue #17 may have been prematurely closed. I have reason to suspect that the crash I received exists in this version of the game still. I have added a safety measure in order or prevent the issue from occurring again. If the day is less than or equal to 0; it gets rounded back up to 1. While unlikely the date will be a negative number defense programming is generally a good thing. I have tried to eyeball the spacing and used a regular Python spacing analyzer as I could not get the project to run in Renpy on my local machine because of a 'NonType' issue in the definitions.rpy file. 