### PR TITLE
Feature: show answer screen after correct answer in quiz

### DIFF
--- a/game/scripts/labels/quiz_session.rpy
+++ b/game/scripts/labels/quiz_session.rpy
@@ -52,6 +52,8 @@ label study_session:
                 $ player_stats.change_stats(quiz_question.category, 10)
 
             player @ laugh "Correct!"
+            # show the correct answer and explanation using a viewport
+            call screen quiz_question_answer_explanation_screen(quiz_question)
         else:
             with vpunch
             player @ pout "Wrong..."

--- a/game/scripts/labels/quiz_session.rpy
+++ b/game/scripts/labels/quiz_session.rpy
@@ -52,13 +52,12 @@ label study_session:
                 $ player_stats.change_stats(quiz_question.category, 10)
 
             player @ laugh "Correct!"
-            # show the correct answer and explanation using a viewport
-            call screen quiz_question_answer_explanation_screen(quiz_question)
         else:
             with vpunch
             player @ pout "Wrong..."
-            # show the correct answer and explanation using a viewport
-            call screen quiz_question_answer_explanation_screen(quiz_question)
+            
+        # show the correct answer and explanation using a viewport
+        call screen quiz_question_answer_explanation_screen(quiz_question)
 
         if quiz_question.easter_egg_name is not None: # Easter Egg achievement
             $ add_achievement(quiz_question.easter_egg_name)


### PR DESCRIPTION
The viewport used when the player gets the wrong answer is shown immediately after the user sees their answer is correct. Everything seems to be in order and nothing appears to detracted by reusing the same screen. 

Checklist:

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)


Closes #69

Closes #49
