### PR TITLE
fix: escape strings displayed with `renpy.say()`

### DIFF
--- a/game/scripts/quiz_questions_from_csv.rpy
+++ b/game/scripts/quiz_questions_from_csv.rpy
@@ -778,7 +778,7 @@ init python:
     difficulty=1,
     ),
     QuizQuestion(
-    question=_("Which one of these values represents 10% of the viewport width?"),
+    question=_("Which one of these values represents 10%% of the viewport width?"),
     true=_("10vw"),
     false=[_("10vh"), _("100vw"), _("1000vw")],
     explanation=_("10vw is equivalent to 10% of the viewport width."),
@@ -794,7 +794,7 @@ init python:
     difficulty=1,
     ),
     QuizQuestion(
-    question=_("Which one of these values represents 20% of the viewport height?"),
+    question=_("Which one of these values represents 20%% of the viewport height?"),
     true=_("20vh"),
     false=[_("200vh"), _("2vh"), _("2000vh")],
     explanation=_("20vh is equivalent to 20% of the viewport height."),


### PR DESCRIPTION
These strings are only used for display by `renpy.say()`, which
interprets Python percent-substitutions for Store Variables, so we need
to escape '%' characters that we intend to display.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #60

<!-- Feel free to add any additional description of changes below this line -->
