### PR TITLE
fix: define completed_curriculum_date variable globally

### DIFF
--- a/game/scripts/variables.rpy
+++ b/game/scripts/variables.rpy
@@ -7,6 +7,7 @@ init 998:
     default calendar = Calendar()
     # start_date will be used to calculate how many days it took for the player to learn to code
     default start_date = calendar.date
+    default completed_curriculum_date = None # set in curriculum.rpy
     
     default calendar_enabled = False
     default stats_unlocked = False


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
When I accepted a job offer, I saw this error:

![Pasted Graphic 4](https://user-images.githubusercontent.com/2051070/209369449-53e73ed9-2a70-4577-a168-65215a53a1ae.jpg)

I'm not totally sure how RenPy works under the hood, but I believe it's because of `$ completed_curriculum_date = date(calendar.get_year(), calendar.get_month(), calendar.get_day())` on this line is scoped locally:

https://github.com/freeCodeCamp/LearnToCodeRPG/blob/e90587e1cbb6ee8d63a75ee57673eab2a7317be4/game/script.rpy#L1345

Not sure if this is the best way to fix it, but this change should allow us to initialize the variable globally, then set it on line 1345 to be used later in `script.rpy`.

Here's a screenshot of accepting a job offer after going back to an earlier save where `completed_curriculum_date` is set, then accepting a job offer:

![image](https://user-images.githubusercontent.com/2051070/209372173-1452849c-ef39-4428-9974-fa621d5a3868.png)
