### PR TITLE
Prevent crashes if the version can't be read

### DIFF
--- a/game/scripts/splashscreen.rpy
+++ b/game/scripts/splashscreen.rpy
@@ -9,6 +9,7 @@ label splashscreen:
     if not renpy.mobile:
         python:
             itch_butler_target = 'freecodecamp/learn-to-code-rpg'
+            retrieved_version_info = False 
             if renpy.linux:
                 itch_butler_channel = 'linux'
             elif renpy.macintosh:
@@ -22,16 +23,16 @@ label splashscreen:
                 itch_version = response.json()['latest'].strip()
                 # compare with local version
                 local_version = get_version()
-
+                retrieved_version_info == True
             except requests.ConnectionError: # no internet
                 pass
-
-        if local_version != itch_version:
-            call screen confirm(
-                _("We've released a new version on itch.io that contains bug fixes and feature enhancements. Would you like to download the new version now?"),
-                OpenURL(itch_url),
-                Return()
-                )
+        if retrieved_version_info == True: 
+            if local_version != itch_version:
+                call screen confirm(
+                    _("We've released a new version on itch.io that contains bug fixes and feature enhancements. Would you like to download the new version now?"),
+                    OpenURL(itch_url),
+                    Return()
+                    )
 
     scene gray90 with Pause(1)
     play sound 'audio/sfx/title_fire_swoosh.ogg'

--- a/game/scripts/splashscreen.rpy
+++ b/game/scripts/splashscreen.rpy
@@ -23,7 +23,7 @@ label splashscreen:
                 itch_version = response.json()['latest'].strip()
                 # compare with local version
                 local_version = get_version()
-                retrieved_version_info == True
+                retrieved_version_info = True
             except requests.ConnectionError: # no internet
                 pass
         if retrieved_version_info == True: 


### PR DESCRIPTION
There's two potential causes for failure. Fail condition one: the local version info in version.txt can't be read. Fail condition number two: itch.io can't be reached. Either way it will crash. This fixes both of them.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #95

<!-- Feel free to add any additional description of changes below this line -->
